### PR TITLE
Quality argument is not the same for every image* function

### DIFF
--- a/smart_resize_image.function.php
+++ b/smart_resize_image.function.php
@@ -98,9 +98,12 @@
     
     # Writing image according to type to the output destination and image quality
     switch ( $info[2] ) {
-      case IMAGETYPE_GIF:   imagegif($image_resized, $output, $quality);    break;
+      case IMAGETYPE_GIF:   imagegif($image_resized, $output);    break;
       case IMAGETYPE_JPEG:  imagejpeg($image_resized, $output, $quality);   break;
-      case IMAGETYPE_PNG:   imagepng($image_resized, $output, $quality);    break;
+      case IMAGETYPE_PNG:
+        $quality = 9 - (int)((0.9*$quality)/10.0);
+        imagepng($image_resized, $output, $quality);
+        break;
       default: return false;
     }
 


### PR DESCRIPTION
Quality argument is not the same for every image\* function:
- imagegif function has no quality argument
- imagepng's quality argument is the compression level from 0 (no compression) to 9
